### PR TITLE
rollup: follow up July 2026 dependency updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,9 +2234,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.5"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",


### PR DESCRIPTION
## Summary

This follow-up roll-up exists because #73 was merged externally while its final checks were still running. Those checks subsequently completed successfully: 21 passed, 0 failed or cancelled, and 2 were expected skips.

After that merge, Dependabot retargeted two existing PRs to newer releases. This PR consolidates exactly those remaining valid changes:

- #71: UUID 1.23.5 to 1.24.0.
- #72: regex 1.13.0 to 1.13.1, including regex-automata 0.4.16.

The original Dependabot authorship is preserved in signed commits. The other open dependency PRs are duplicates of changes already merged through #73; they will be closed only after this PR's current head is fully green.

## Validation

- `RUSTUP_TOOLCHAIN=1.95.0 make ci-local`
- `RUSTUP_TOOLCHAIN=1.95.0 make test-no-features build-examples test-doc doc-check doc-links feature-test`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo metadata --locked --no-deps --format-version 1`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo audit`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo deny check`
- `git diff --check origin/main...HEAD`

One first-pass wall-clock assertion exceeded 100 ms under shared-runner load. That unchanged timing test passed five isolated reruns at 14–23 ms and passed again inside the complete no-feature rerun; no code change was warranted.

All local CI stages pass. The deny gate retains its existing permitted duplicate and unmatched-license warnings, and the optional deadlink checker retains its known modern-rustdoc generated-link warnings.

Final-head hosted CI completed with 21 passing checks, 0 failures or cancellations, and 2 expected skips.
