### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,127 +1,125 @@
 name: Auto Release
 
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
 on:
+  workflow_run:
+    workflows: ["CI", "Security Audit"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'Cargo.toml'
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: read
 
-concurrency:
-  group: auto-release-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  check-version:
-    name: Check Version
+  check:
+    name: Check for Release
     runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
     outputs:
-      version_changed: ${{ steps.version_check.outputs.changed }}
-      new_version: ${{ steps.version_check.outputs.version }}
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
-      - name: Checkout sources
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
 
-      - name: Verify release source
-        shell: bash
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "Auto Release must run from the main branch, got $GITHUB_REF" >&2
-            exit 1
-          fi
-          git fetch --no-tags origin main
-          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-            echo "The selected commit is no longer the tip of origin/main" >&2
-            exit 1
-          fi
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: 1.97.1
-
-      - name: Check if version changed
-        id: version_check
-        run: |
-          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          git check-ref-format "refs/tags/v${NEW_VERSION}"
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-          # Check if tag exists
-          if git rev-parse --verify --quiet "refs/tags/v$NEW_VERSION" >/dev/null; then
-            echo "Version v$NEW_VERSION already exists"
-            echo "changed=false" >> "$GITHUB_OUTPUT"
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
           else
-            echo "New version detected: v$NEW_VERSION"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-  verify-package:
-    name: Verify Package
-    needs: check-version
-    if: needs.check-version.outputs.version_changed == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: 1.97.1
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Run tests
-        run: cargo test --locked
-
-      - name: Verify package contents
-        run: python3 scripts/check_package.py
-
-      - name: Verify crate package
-        run: cargo package --locked
-
-  create-release:
+  release:
     name: Create Release
-    needs: [check-version, verify-package]
-    if: needs.check-version.outputs.version_changed == 'true'
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
+      actions: write
     steps:
-      - name: Checkout sources
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
 
-      - name: Create tag
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}
+
+      # Tags created with GITHUB_TOKEN do not trigger tag-push workflows, so
+      # dispatch the tag pipelines explicitly.
+      - name: Trigger tag pipelines
+        if: steps.release.outputs.released == 'true'
         env:
-          RELEASE_VERSION: ${{ needs.check-version.outputs.new_version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          git fetch --no-tags origin main
-          if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
-            echo "main advanced after package verification; restart the release" >&2
-            exit 1
-          fi
-          git check-ref-format "refs/tags/v${RELEASE_VERSION}"
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag -a "v${RELEASE_VERSION}" -m "Release v${RELEASE_VERSION}"
-          git push origin "v${RELEASE_VERSION}"
-
-      - name: Dispatch release workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_VERSION: ${{ needs.check-version.outputs.new_version }}
-        run: >-
-          gh workflow run release.yml
-          --ref "v${RELEASE_VERSION}"
-          --field "version=${RELEASE_VERSION}"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f version="$VERSION"


### PR DESCRIPTION
## What this does

Replaces `.github/workflows/auto-release.yml` with the shared ThreatFlux auto-release action (`ThreatFlux/github_actions/release`, SHA-pinned to `16d779cd569c34743eb6683ca4c0ce105e9ad234` = v0.4.2).

**How the action works:** on every green push to `main` it analyzes conventional commits since the last release tag, computes the next semver bump, rewrites `Cargo.toml`/`Cargo.lock`, commits, tags, and publishes a GitHub Release — entirely through the GitHub API (no git or cargo invocations at runtime). Merges containing only `chore:`/`docs:`-type commits produce **no release**; the action no-ops until a `feat:`/`fix:`/breaking commit lands. A `workflow_dispatch` input allows forcing a `patch`/`minor`/`major` bump.

**Gating:** the workflow runs on `workflow_run` completion of both **CI** and **Security Audit**, and only releases when the push runs of *both* workflows succeeded for the exact target commit.

## Replaced behavior

The previous `auto-release.yml` watched for manual `Cargo.toml` version edits pushed to `main`, ran pre-tag verification (`cargo test`, `scripts/check_package.py`, `cargo package`), created an **annotated** tag, and dispatched `release.yml`. With this change:

- Version bumps are now derived from conventional commits instead of manual `Cargo.toml` edits.
- Pre-tag verification moves entirely to the CI/Security gate plus `release.yml`'s own `verify-package` job (which runs the same tests/package checks); nothing is verified between the gate and the tag itself.
- The tag is now a **lightweight** tag created via the API, not an annotated tag (see the caveat below).
- No crates.io publish or changelog behavior was removed from `auto-release.yml` — those live in `release.yml`, which is untouched.

## Tag-trigger limitation and dispatch chaining

Tags created with `GITHUB_TOKEN` do not fire tag-push workflows, so the new workflow explicitly dispatches `release.yml` via `gh workflow run release.yml --ref "$TAG" -f version="$VERSION"` after a successful release (release.yml's `workflow_dispatch` accepts a required `version` input, which is passed). There is no `docker.yml` in this repo, so no other tag pipeline needs chaining.

## ⚠️ Known incompatibility requiring follow-up

`release.yml`'s **Verify release provenance** step requires the tag to be an *annotated* tag object (`git cat-file -t` must return `tag`). The auto-release action creates a **lightweight** tag via `POST /git/refs` (verified in the action source at the pinned SHA). As a result, the dispatched `release.yml` run will currently fail at that step, skipping the crates.io publish and the softprops GitHub Release (the auto-release action still creates its own GitHub Release via the API). Deliberately **not** changed here since that step is a security control — maintainers should decide whether to accept lightweight tags (e.g. allow object type `commit` while keeping the `merge-base --is-ancestor origin/main` check) or keep manual releases for crates.io.

## Template bug fixes

None applicable: `release.yml` has no native build matrix step, no Windows packaging step, and no heredoc in its crates.io publish path (all jobs run on `ubuntu-latest`), and `docker.yml` does not exist.

## Notes

- Action ref is SHA-pinned to v0.4.2.
- The release commit the action pushes is `chore: release v{version}`, so the release commit itself never triggers a further bump; likewise this PR's `ci:` commit will not trigger a release on merge.
- Validated with `yaml.safe_load` and `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
