### PR TITLE
chore: pin release automation to v0.7.1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-    uses: ThreatFlux/github_actions/.github/workflows/reusable-auto-release.yml@e9bec9898080aa55bec9f3ce4351bae37f8b88cd
+    uses: ThreatFlux/github_actions/.github/workflows/reusable-auto-release.yml@99bd76d2bd4d2e79eaa18abe89de2c352bc1b9a2 # v0.7.1
     with:
       bump: ${{ github.event.inputs.version_bump || 'auto' }}
       required-workflows: ci.yml,security.yml


### PR DESCRIPTION
Pins this repository's release automation to [`ThreatFlux/github_actions` v0.7.1](https://github.com/ThreatFlux/github_actions/releases/tag/v0.7.1) (`99bd76d`).

## Why v0.7.1 specifically

The previous pin (`e9bec98`, v0.6.0-era) is not just behind on features — it executed a **stale binary**. The reusable workflow checks the action out at `job.workflow_sha` and runs it as a Docker container action, and `runtime/Dockerfile` pinned the prebuilt `0.6.2` image at every tag through v0.7.0. So any ref up to and including v0.7.0 ran a 0.6.2 binary no matter what the workflow YAML said.

That was fixed in [ThreatFlux/github_actions#57](https://github.com/ThreatFlux/github_actions/pull/57), which makes **v0.7.1 the first tag whose runtime image matches the release**.

## What this pin brings in

- Release-tag resolution fix for bundle-tagged actions and alternate registries
- Cargo dependency handling fixes
- New read-only `policy` command (workflow script usage and baseline policy findings)
- Optional GitHub App authentication for release commits and PRs, via the new `github-app-id` / `github-app-private-key` inputs

## Compatibility

Pure pin bump — no changes needed in this repository's workflow. I diffed the reusable workflow's `workflow_call` surface between the old pin and v0.7.1: the only changes are the two **optional** GitHub App inputs above. **No inputs or secrets were removed or renamed**, and no defaults that this repo relies on changed.

The GitHub App inputs are opt-in; leaving them unset keeps the existing `GITHUB_TOKEN` behavior.
