### PR TITLE
ci: repin github_actions release automation to v0.7.4

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,12 +25,14 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   release:
     permissions:
       actions: write
       contents: write
+      pull-requests: write
     uses: ThreatFlux/github_actions/.github/workflows/reusable-auto-release.yml@e61e4dcdf74b3bda415f99604965fd82ac16f48a # v0.7.4
     with:
       bump: ${{ github.event.inputs.version_bump || 'auto' }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       actions: write
       contents: write
-    uses: ThreatFlux/github_actions/.github/workflows/reusable-auto-release.yml@e9bec9898080aa55bec9f3ce4351bae37f8b88cd
+    uses: ThreatFlux/github_actions/.github/workflows/reusable-auto-release.yml@e61e4dcdf74b3bda415f99604965fd82ac16f48a # v0.7.4
     with:
       bump: ${{ github.event.inputs.version_bump || 'auto' }}
       required-workflows: ci.yml,security.yml


### PR DESCRIPTION
Repins the reusable auto-release workflow to `ThreatFlux/github_actions@e61e4dc` (v0.7.4), which fixes the workflow startup failure caused by a `secrets` context reference in a step-level `if:`.

Validated end to end on `ThreatFlux/yrlint`: CI -> Auto Release -> published release.